### PR TITLE
Remove leading space in YAML delimiter

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,4 +1,4 @@
- ---
+---
 title: I downvoted because...
 byline: — a website designed to help you help others!
 ---


### PR DESCRIPTION
The leading space was causing `---` to be interpreted as a horizontal rule instead of the opening delimiter of a YAML front matter.