### PR TITLE
Fix Stack Overflow links to use HTTPS

### DIFF
--- a/stackoverflow/imageofanexception.md
+++ b/stackoverflow/imageofanexception.md
@@ -39,7 +39,7 @@ If you are debugging in Visual Studio, the Exception Helper Dialog contains a li
 
 ![The link to copy exception details to the clipboard on the exception helper dialog](/images/stackoverflow/exceptionimage2.PNG)
 
-If you are experiencing the Exception at runtime, you can [catch the exception](http://stackoverflow.com/questions/9526139/how-to-catch-exceptions) and call `ToString()` on it. Log the result, using whatever method is most convenient for you.
+If you are experiencing the Exception at runtime, you can [catch the exception](https://stackoverflow.com/questions/9526139/how-to-catch-exceptions) and call `ToString()` on it. Log the result, using whatever method is most convenient for you.
 
 ## Leave a comment! {#leaveacomment}
 Once you have done this, leave a comment to the person who sent you this link. They will be happy to retract their downvote.

--- a/stackoverflow/nocode.md
+++ b/stackoverflow/nocode.md
@@ -20,7 +20,7 @@ As it is, the question is barely answerable. Any solution would be based on gues
 It also shows that not much effort was put into writing the question. Remember, you are asking people to *help you,* ***free of charge***.  Giving people enough information to answer your question is the least you can do. Failing to do so *wastes other people's time*, and wasting the time of other users who are trying to help is very rude.
 
 ## What to do next {#whattodonext}
-Edit the post to add a Minimal, Complete, Verifiable Example (see [the Stack Overflow help center](http://stackoverflow.com/help/mcve) for details on how to do this).
+Edit the post to add a Minimal, Complete, Verifiable Example (see [the Stack Overflow help center](https://stackoverflow.com/help/mcve) for details on how to do this).
 
 The code should not be [directly copy/pasted]({% link stackoverflow/toomuchcode.md %}) from your editor or IDE! Instead, it should be cut down to only keep the parts essential to identify and reproduce the issue.
 

--- a/stackoverflow/noexceptiondetails.md
+++ b/stackoverflow/noexceptiondetails.md
@@ -38,7 +38,7 @@ If you are debugging in Visual Studio, the Exception Helper Dialog contains a li
 
 ![The link to copy exception details to the clipboard on the exception helper dialog](/images/stackoverflow/exceptionimage2.PNG)
 
-If you are experiencing the Exception at runtime, you can [catch the exception](http://stackoverflow.com/questions/9526139/how-to-catch-exceptions) and call `ToString()` on it. Log the result, using whatever method is most convenient for you.
+If you are experiencing the Exception at runtime, you can [catch the exception](https://stackoverflow.com/questions/9526139/how-to-catch-exceptions) and call `ToString()` on it. Log the result, using whatever method is most convenient for you.
 
 Once you have gathered all the details from the exception, you can paste it into your question in an edit. **This is important**--do not try to paste the exception details into a _comment_, as there is not enough room for all the of details. There is an "edit" link at the bottom of your question, click it and paste the details into your question. And don't forget to format it!
 

--- a/stackoverflow/toomuchcode.md
+++ b/stackoverflow/toomuchcode.md
@@ -19,7 +19,7 @@ The noise generated from all the code surrounding the error prevents future user
 It also shows that not much effort was put into creating your question. People are volunteering their time, _free of charge_, to help you. You need to be considerate of their efforts. One of the easiest, and most helpful, ways to do this is to pare down your code to the minimum needed to illustrate your problem.
 
 ## What to do next {#whattodonext}
-Isolate the issue, and create a Minimal, Complete, Verifiable example ([see the StackOverflow help center for more details](http://stackoverflow.com/help/mcve)). Such an example is generally only a few lines of code, like a function or a database request.
+Isolate the issue, and create a Minimal, Complete, Verifiable example ([see the StackOverflow help center for more details](https://stackoverflow.com/help/mcve)). Such an example is generally only a few lines of code, like a function or a database request.
 
 The code should be debugged to identify _the precise spot at which the issue occurs_. It should then either be rewritten from scratch until the issue reappears or the original code should be largely cut through to remove working pieces which are not directly related to the issue.
 


### PR DESCRIPTION
Stack Overflow recently migrated all their links to HTTPS (e.g., see [this](https://meta.stackoverflow.com/q/345012/2422776)).

This PR changes all the SO links in this repository to use HTTPS