### PR TITLE
Capitalize title of No MCVE article

### DIFF
--- a/stackoverflow/nomcve.md
+++ b/stackoverflow/nomcve.md
@@ -1,5 +1,5 @@
 ---
-title: no MCVE
+title: No MCVE
 byline: lacking an MCVE makes it hard to answer
 permalink: nomcve/
 categories: "Stack Overflow"


### PR DESCRIPTION
The titles on all of the other articles are capitalized, so this makes it consistent. (The homepage was driving me nuts.)