### PR TITLE
Fix formatting of MCVE list

### DIFF
--- a/stackoverflow/nomcve.md
+++ b/stackoverflow/nomcve.md
@@ -14,6 +14,7 @@ A question without any code, or where the code provided is not
  * minimal – as little code as possible that still produces the same problem
  * complete – contains all parts needed to reproduce the problem
  * verifiable – would compile if run, and exhibits the problem described in the question
+
 cannot be easily, if at all, answered.
 
 When a code sample has these qualities, it is generally referred to as an [MCVE](https://stackoverflow.com/help/mcve).


### PR DESCRIPTION
Add an empty line in order to prevent the end of the sentence that should be displayed _below_ the list from being appended to the last list item.

![image](https://user-images.githubusercontent.com/6010463/79695365-b903b080-8276-11ea-82c0-8e06e62f8f8f.png)
👆 this should be below the list
